### PR TITLE
add wrapper script for perl environment

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,7 +9,7 @@ confinement: devmode
 
 apps:
     get-iplayer:
-        command: get_iplayer
+        command: wrapper.sh
         plugs:
         - network 
 
@@ -17,9 +17,6 @@ parts:
     get-iplayer:
         source: https://github.com/get-iplayer/get_iplayer.git
         plugin: dump
-        install: |
-            cp ./get_iplayer $SNAPCRAFT_PART_INSTALL/
-            
         stage-packages:
         - perl
         - libwww-perl
@@ -30,6 +27,10 @@ parts:
         - libcgi-pm-perl
         - atomicparsley
         - ffmpeg
-        
-        
-    
+    wrapper:
+      plugin: nil
+      source: .
+      install: |
+        cp wrapper.sh $SNAPCRAFT_PART_INSTALL/
+      after:
+        - get-iplayer

--- a/wrapper.sh
+++ b/wrapper.sh
@@ -1,0 +1,25 @@
+#! /bin/sh
+
+set -e
+
+case $(arch) in
+	x86_64)
+		TRIPLET=x86_64-linux-gnu
+		;;
+	armv7l)
+		TRIPLET=arm-linux-gnueabihf
+		;;
+esac
+
+export LC_ALL=C.UTF-8
+export LANG=C.UTF-8
+export LANGUAGE=C.UTF-8
+
+PERLCMD="$SNAP/usr/bin/perl5.22-$TRIPLET -I \
+	$SNAP/usr/lib/$TRIPLET/perl5/5.22 -I \
+	$SNAP/usr/share/perl5 -I \
+	$SNAP/usr/share/perl5/5.22 -I \
+        $SNAP/usr/share/perl/5.22.1 -I \
+        $SNAP/usr/lib/$TRIPLET/perl/5.22.1"
+
+$PERLCMD $SNAP/get_iplayer --ffmpeg=$SNAP/usr/bin/ffmpeg "$@"


### PR DESCRIPTION
- add a wrapper.sh script that sets the perl search paths and locales
- add a wrapper part to snapcraft.yaml to put the script in place